### PR TITLE
modules: fix typo in error message

### DIFF
--- a/modules/emulate_payload.py
+++ b/modules/emulate_payload.py
@@ -623,7 +623,7 @@ def start_speakeasy(self, kwargs, cfg):
 
     if not access(payload, R_OK):
         self.poutput(
-            Fore.RED + '[!] Payload file existing or not readable ' + Style.RESET_ALL)
+            Fore.RED + '[!] Payload file not existing or not readable ' + Style.RESET_ALL)
         return
     if unhook != None:
         try:


### PR DESCRIPTION
Fix typo in displayed error message if payload file does not exist.